### PR TITLE
Fix three code bugs

### DIFF
--- a/backend/api/models.py
+++ b/backend/api/models.py
@@ -4,8 +4,8 @@ SQLAlchemy ORM Models
 Database models corresponding to the schema.
 """
 
-from sqlalchemy import Column, String, DECIMAL, BigInteger, TIMESTAMP, Boolean, ARRAY, Text, ForeignKey
-from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy import Column, String, DECIMAL, BigInteger, TIMESTAMP, Boolean, Text, ForeignKey
+from sqlalchemy.dialects.postgresql import UUID, ARRAY
 from sqlalchemy.sql import func
 from .database import Base
 import uuid

--- a/backend/api/routers/signals.py
+++ b/backend/api/routers/signals.py
@@ -18,7 +18,7 @@ router = APIRouter()
 async def get_all_signals(
     limit: int = Query(default=20, le=100),
     offset: int = Query(default=0, ge=0),
-    signal_type: Optional[str] = Query(default=None, regex="^(BUY|SELL|HOLD)$"),
+    signal_type: Optional[str] = Query(default=None, pattern="^(BUY|SELL|HOLD)$"),
     min_strength: Optional[float] = Query(default=None, ge=0, le=100),
     db: Session = Depends(get_db)
 ):

--- a/data/signals/signal_generator.py
+++ b/data/signals/signal_generator.py
@@ -16,7 +16,7 @@ Rules (MVP):
         - None of the above conditions met
 """
 
-from typing import Dict, List, Literal
+from typing import Any, Dict, List, Literal
 import pandas as pd
 
 SignalType = Literal["BUY", "SELL", "HOLD"]
@@ -28,7 +28,7 @@ def generate_signal(
     macd_signal: float,
     macd_histogram: float,
     price: float
-) -> Dict[str, any]:
+) -> Dict[str, Any]:
     """
     Generate trading signal from technical indicators.
 

--- a/data/utils/data_validation.py
+++ b/data/utils/data_validation.py
@@ -5,10 +5,10 @@ Quality checks for market data before processing.
 """
 
 import pandas as pd
-from typing import List, Dict
+from typing import Any, List, Dict
 
 
-def validate_ohlcv_data(df: pd.DataFrame) -> Dict[str, any]:
+def validate_ohlcv_data(df: pd.DataFrame) -> Dict[str, Any]:
     """
     Validate OHLCV data quality.
 


### PR DESCRIPTION
Fix deprecated FastAPI `regex` usage, correct `any` typing to `Any`, and import SQLAlchemy `ARRAY` from the correct dialect.

The `Query(regex=...)` parameter was deprecated in Pydantic v2/FastAPI, leading to potential runtime errors. The `any` type was incorrectly used instead of `typing.Any`, causing type-checking issues. The `ARRAY` type was imported from `sqlalchemy` instead of `sqlalchemy.dialects.postgresql`, resulting in a runtime `ImportError`.

---
<a href="https://cursor.com/background-agent?bcId=bc-244b3078-4944-4e54-acc1-62faedbf3864"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-244b3078-4944-4e54-acc1-62faedbf3864"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

